### PR TITLE
changed the checksum label to be md5

### DIFF
--- a/ou_bagit_importer.drush.inc
+++ b/ou_bagit_importer.drush.inc
@@ -130,7 +130,7 @@ function ou_bagit_importer_batch_import_page($source_uri, $drupal_directory, $ob
     'source_uri' => $source_uri,
     'drupal_directory' => $drupal_directory,
     'file' => $page['file'],
-    'hash' => $page['sha1'],
+    'hash' => $page['md5'],
     'exif' => $page['exif'],
     'type' => 'islandora:pageCModel',
     'book' => $json_data['uuid'],


### PR DESCRIPTION
This branch contains the updated importer code from Ashok's repository. The code was also modified to use the recipe files with checksum labeled with "md5" instead of "sha1".
